### PR TITLE
[사용자] 삭제(DeletedDate)로 인한 팔로우, 회원, 스토어 패치 조인 적용 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/lotte/danuri/member/cart/CartRepository.java
+++ b/src/main/java/com/lotte/danuri/member/cart/CartRepository.java
@@ -10,4 +10,6 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<List<Cart>> findByMemberId(Long memberId);
 
+    void deleteAllByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/lotte/danuri/member/cart/CartService.java
+++ b/src/main/java/com/lotte/danuri/member/cart/CartService.java
@@ -17,4 +17,6 @@ public interface CartService {
 
     int delete(CartDeleteReqDto dto);
 
+    int deleteAllByMember(Long memberId);
+
 }

--- a/src/main/java/com/lotte/danuri/member/cart/CartServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/cart/CartServiceImpl.java
@@ -61,4 +61,10 @@ public class CartServiceImpl implements CartService{
         cartRepository.deleteById(dto.getId());
         return 1;
     }
+
+    @Override
+    public int deleteAllByMember(Long memberId) {
+        cartRepository.deleteAllByMemberId(memberId);
+        return 1;
+    }
 }

--- a/src/main/java/com/lotte/danuri/member/common/exception/codes/MemberErrorCode.java
+++ b/src/main/java/com/lotte/danuri/member/common/exception/codes/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
 
     NO_AUTHORIZED_SELLER(HttpStatus.FORBIDDEN, "Seller is unauthorized"),
-    NO_MEMBER_EXISTS(HttpStatus.NOT_FOUND, "Member is not Existed")
+    NO_MEMBER_EXISTS(HttpStatus.NOT_FOUND, "Member is not Existed"),
+    SELLER_STORE_EXISTS(HttpStatus.FORBIDDEN, "Seller still has store, can't withdraw from membership")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lotte/danuri/member/common/exception/exceptions/SellerStoreExistedException.java
+++ b/src/main/java/com/lotte/danuri/member/common/exception/exceptions/SellerStoreExistedException.java
@@ -1,0 +1,11 @@
+package com.lotte.danuri.member.common.exception.exceptions;
+
+import com.lotte.danuri.member.common.exception.codes.ErrorCode;
+
+public class SellerStoreExistedException extends CustomException {
+
+    public SellerStoreExistedException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+}

--- a/src/main/java/com/lotte/danuri/member/common/exception/handlers/MemberExceptionHandler.java
+++ b/src/main/java/com/lotte/danuri/member/common/exception/handlers/MemberExceptionHandler.java
@@ -3,6 +3,7 @@ package com.lotte.danuri.member.common.exception.handlers;
 import com.lotte.danuri.member.common.exception.ErrorResponse;
 import com.lotte.danuri.member.common.exception.exceptions.NoAuthorizationException;
 import com.lotte.danuri.member.common.exception.exceptions.NoMemberException;
+import com.lotte.danuri.member.common.exception.exceptions.SellerStoreExistedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -22,6 +23,13 @@ public class MemberExceptionHandler {
     @ExceptionHandler(NoMemberException.class)
     public ResponseEntity<?> handleNoMemberException(NoMemberException e) {
         log.error("handleNoMemberException", e);
+        ErrorResponse response = new ErrorResponse(e.getErrorCode());
+        return new ResponseEntity<>(response, e.getErrorCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(SellerStoreExistedException.class)
+    public ResponseEntity<?> handleSellerStoreExistedException(SellerStoreExistedException e) {
+        log.error("handleSellerStoreExistedException", e);
         ErrorResponse response = new ErrorResponse(e.getErrorCode());
         return new ResponseEntity<>(response, e.getErrorCode().getHttpStatus());
     }

--- a/src/main/java/com/lotte/danuri/member/coupon/MyCouponService.java
+++ b/src/main/java/com/lotte/danuri/member/coupon/MyCouponService.java
@@ -15,4 +15,6 @@ public interface MyCouponService {
     int updateStatus(Long myCouponId, int status);
 
     int delete(Long myCouponId);
+
+    int deleteAllByMember(Long memberId);
 }

--- a/src/main/java/com/lotte/danuri/member/coupon/MyCouponServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/coupon/MyCouponServiceImpl.java
@@ -81,4 +81,12 @@ public class MyCouponServiceImpl implements MyCouponService {
         coupon.delete();
         return 1;
     }
+
+    @Override
+    public int deleteAllByMember(Long memberId) {
+        myCouponRepository.findByMemberIdAndDeletedDateIsNull(memberId).orElseGet(ArrayList::new)
+            .forEach(MyCoupon::delete);
+
+        return 1;
+    }
 }

--- a/src/main/java/com/lotte/danuri/member/follow/Follow.java
+++ b/src/main/java/com/lotte/danuri/member/follow/Follow.java
@@ -22,11 +22,11 @@ import lombok.RequiredArgsConstructor;
 @AllArgsConstructor
 public class Follow extends BaseEntity {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "STORE_ID")
     private Store store;
 

--- a/src/main/java/com/lotte/danuri/member/follow/FollowRepository.java
+++ b/src/main/java/com/lotte/danuri/member/follow/FollowRepository.java
@@ -2,7 +2,10 @@ package com.lotte.danuri.member.follow;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,5 +14,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Optional<List<Follow>> findByStoreId(Long storeId);
 
     Optional<Follow> findByMemberIdAndStoreIdAndDeletedDateIsNull(Long memberId, Long storeId);
+
+    Optional<List<Follow>> findByMemberIdAndDeletedDateIsNull(Long memberId);
 
 }

--- a/src/main/java/com/lotte/danuri/member/follow/FollowService.java
+++ b/src/main/java/com/lotte/danuri/member/follow/FollowService.java
@@ -14,6 +14,8 @@ public interface FollowService {
 
     int delete(FollowDto dto);
 
+    int deleteAllByMember(Long memberId);
+
     List<Long> getMembersByFollow(Long storeId);
 
 }

--- a/src/main/java/com/lotte/danuri/member/follow/FollowServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/follow/FollowServiceImpl.java
@@ -93,6 +93,13 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
+    public int deleteAllByMember(Long memberId) {
+        followRepository.findByMemberIdAndDeletedDateIsNull(memberId).orElseGet(ArrayList::new)
+            .forEach(Follow::delete);
+        return 1;
+    }
+
+    @Override
     public List<Long> getMembersByFollow(Long storeId) {
 
         Store store = storeRepository.findById(storeId).orElseThrow(

--- a/src/main/java/com/lotte/danuri/member/likes/LikesRepository.java
+++ b/src/main/java/com/lotte/danuri/member/likes/LikesRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface LikesRepository extends JpaRepository<Likes, Long> {
 
     Optional<List<Likes>> findByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/lotte/danuri/member/likes/LikesService.java
+++ b/src/main/java/com/lotte/danuri/member/likes/LikesService.java
@@ -13,4 +13,6 @@ public interface LikesService {
 
     int delete(LikesDeleteReqDto dto);
 
+    int deleteAllByMember(Long memberId);
+
 }

--- a/src/main/java/com/lotte/danuri/member/likes/LikesServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/likes/LikesServiceImpl.java
@@ -49,5 +49,11 @@ public class LikesServiceImpl implements LikesService{
         return 1;
     }
 
+    @Override
+    public int deleteAllByMember(Long memberId) {
+        likesRepository.deleteAllByMemberId(memberId);
+        return 1;
+    }
+
 
 }

--- a/src/main/java/com/lotte/danuri/member/members/Member.java
+++ b/src/main/java/com/lotte/danuri/member/members/Member.java
@@ -2,15 +2,21 @@ package com.lotte.danuri.member.members;
 
 import com.lotte.danuri.member.domain.BaseEntity;
 import com.lotte.danuri.member.follow.Follow;
+import java.time.LocalDateTime;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
+import javax.persistence.EntityManager;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.springframework.data.jpa.repository.Query;
 
 @Entity(name="member")
 @Getter
@@ -28,6 +34,9 @@ public class Member extends BaseEntity {
     private int role;
     private int status;
 
+    private LocalDateTime deletedDate;
+
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Follow> followList;
 
@@ -45,6 +54,10 @@ public class Member extends BaseEntity {
         if(!this.followList.contains(follow)) {
             this.followList.add(follow);
         }
+    }
+
+    public void delete() {
+        this.deletedDate = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberController.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberController.java
@@ -1,9 +1,13 @@
 package com.lotte.danuri.member.members;
 
+import com.lotte.danuri.member.cart.CartService;
+import com.lotte.danuri.member.coupon.MyCouponService;
+import com.lotte.danuri.member.follow.FollowService;
 import com.lotte.danuri.member.likes.Likes;
 import com.lotte.danuri.member.likes.LikesService;
 import com.lotte.danuri.member.likes.dto.LikesReqDto;
 import com.lotte.danuri.member.members.dto.MemberInfoReqDto;
+import com.lotte.danuri.member.members.dto.MemberReqDto;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,6 +26,9 @@ public class MemberController {
 
     private final MemberService memberService;
     private final LikesService likesService;
+    private final CartService cartService;
+    private final MyCouponService myCouponService;
+    private final FollowService followService;
 
     @PatchMapping("/info")
     public ResponseEntity<?> updateInfo(@RequestBody MemberInfoReqDto dto) {
@@ -63,6 +70,19 @@ public class MemberController {
         return new ResponseEntity<>(productList, HttpStatus.OK);
     }
 
+    @PatchMapping("/deletes")
+    public ResponseEntity<?> delete(@RequestBody MemberReqDto dto) {
+
+        Long memberId = dto.getMemberId();
+
+        memberService.delete(memberId);
+        cartService.deleteAllByMember(memberId);
+        myCouponService.deleteAllByMember(memberId);
+        followService.deleteAllByMember(memberId);
+        likesService.deleteAllByMember(memberId);
+
+        return new ResponseEntity<>("회원 탈퇴 완료", HttpStatus.OK);
+    }
 
 
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberRepository.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberRepository.java
@@ -2,10 +2,22 @@ package com.lotte.danuri.member.members;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     // [관리자] 판매자 조회 - role:3, status: -1(탈퇴),0(대기중),1(권한부여완료)
     Optional<List<Member>> findByRoleAndStatus(int role, int status);
+
+    @Query(
+        value = "SELECT distinct m FROM member m JOIN FETCH m.followList f "
+            + "WHERE m.id = :memberId "
+            + "AND f.member.id = :memberId "
+            + "AND m.deletedDate is null "
+            + "AND f.deletedDate is null "
+    )
+    Optional<Member> findById(Long memberId);
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberService.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberService.java
@@ -12,4 +12,6 @@ public interface MemberService {
 
     MemberRespDto getMember(Long memberId);
 
+    int delete(Long memberId);
+
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberServiceImpl.java
@@ -1,10 +1,14 @@
 package com.lotte.danuri.member.members;
 
+import com.lotte.danuri.member.cart.CartRepository;
+import com.lotte.danuri.member.common.exception.codes.ErrorCode;
 import com.lotte.danuri.member.common.exception.codes.MemberErrorCode;
 import com.lotte.danuri.member.common.exception.exceptions.NoMemberException;
+import com.lotte.danuri.member.common.exception.exceptions.SellerStoreExistedException;
 import com.lotte.danuri.member.members.dto.MemberInfoReqDto;
 import com.lotte.danuri.member.members.dto.MemberRespDto;
 import com.lotte.danuri.member.members.dto.SellerAuthReqDto;
+import com.lotte.danuri.member.store.StoreRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -18,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
 
     @Override
     public Long updateMemberInfo(MemberInfoReqDto dto) {
@@ -45,5 +50,22 @@ public class MemberServiceImpl implements MemberService {
             .phoneNumber(member.getPhoneNumber())
             .build();
 
+    }
+
+    @Override
+    public int delete(Long memberId) {
+
+        Member member = memberRepository.findById(memberId).orElseThrow(
+            () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
+        );
+
+        int role = member.getRole();
+        if(role == 2 && storeRepository.findByMemberIdAndDeletedDateIsNull(member.getId()).isPresent()) {
+            throw new SellerStoreExistedException(MemberErrorCode.SELLER_STORE_EXISTS.getMessage(), MemberErrorCode.SELLER_STORE_EXISTS);
+        }
+
+        member.delete();
+
+        return 0;
     }
 }

--- a/src/main/java/com/lotte/danuri/member/store/StoreRepository.java
+++ b/src/main/java/com/lotte/danuri/member/store/StoreRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
@@ -13,5 +12,14 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
     Optional<Store> findByNameAndDeletedDateIsNull(String name);
 
     Optional<List<Store>> findByIdIn(List<Long> storeIds);
+
+    @Query(
+        value = "SELECT distinct s FROM Store s JOIN FETCH s.followList f "
+            + "WHERE s.id = :storeId "
+            + "AND f.member.id = :memberId "
+            + "AND s.deletedDate is null "
+            + "AND f.deletedDate is null "
+    )
+    Optional<Store> findById(Long storeId);
 
 }


### PR DESCRIPTION
[작업 내용]
* '삭제' 시 실제 데이터를 delete 하는 것이 아닌 deletedDate를 update하기 때문에 팔로우와 양방향 연관관계가 맺어진 회원, 스토어의 자식 데이터인 팔로우 리스트에 삭제 처리된 데이터까지 같이 조회되는 문제가 발생
  * deletedDate가 널인 데이터만 조회할 수 있도록 패치 조인을 사용하여 JpaRepository의 findById 메소드를 재구현하여 해결

* 회원 탈퇴 기능 구현
  * 회원 탈퇴 시 회원에 해당된 모든 데이터가 삭제 처리 필요 -> delete 아닌 update 처리해야 하므로 각 도메인에 수정할 메소드 추가 구현
  * 회원 중 셀러일 경우 스토어를 먼저 삭제하지 않으면 회원 탈퇴하지 못하도록 SellerStoreException을 구현하여 적용
 