### PR TITLE
[셀러] 스토어 -> 브랜드, 지점으로 엔티티 수정

### DIFF
--- a/src/main/java/com/lotte/danuri/member/store/Brand.java
+++ b/src/main/java/com/lotte/danuri/member/store/Brand.java
@@ -1,0 +1,27 @@
+package com.lotte.danuri.member.store;
+
+import com.lotte.danuri.member.domain.BaseEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Brand extends BaseEntity {
+
+    private String name;
+    private String image;
+    private LocalDateTime deletedDate;
+
+    @OneToMany(mappedBy = "brand", fetch = FetchType.LAZY)
+    private List<Store> storeList;
+}

--- a/src/main/java/com/lotte/danuri/member/store/Store.java
+++ b/src/main/java/com/lotte/danuri/member/store/Store.java
@@ -10,6 +10,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
@@ -35,10 +36,6 @@ public class Store extends BaseEntity {
 
     private String address;
 
-    private Double score;
-
-    private String ownerName;
-
     private String ownerNumber;
 
     private String image;
@@ -48,6 +45,10 @@ public class Store extends BaseEntity {
     @OneToMany(mappedBy = "store", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Follow> followList;
 
+    @ManyToOne
+    @JoinColumn(name = "BRAND_ID")
+    private Brand brand;
+
     public StoreDto toDto() {
         return StoreDto.builder()
             .id(getId())
@@ -55,10 +56,8 @@ public class Store extends BaseEntity {
             .name(name)
             .address(address)
             .description(description)
-            .ownerName(ownerName)
             .ownerNumber(ownerNumber)
             .image(image)
-            .score(score)
             .build();
     }
 
@@ -66,7 +65,6 @@ public class Store extends BaseEntity {
         this.name = dto.getName();
         this.description = dto.getDescription();
         this.address = dto.getAddress();
-        this.ownerName = dto.getOwnerName();
         this.ownerNumber = dto.getOwnerNumber();
     }
 


### PR DESCRIPTION
[작업 내용]
* 기존의 스토어가 셀러의 오픈마켓과 같은 개념에서 명품 브랜드의 지점으로 수정됨
* Brand 엔티티 새로 생성 및 Store의 불필요 필드 삭제, Brand - Store 연관관계 설정