### PR TITLE
[FEAT] 회원가입 시 개인정보 저장을 위한 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,35 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2021.0.4")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-web-services'
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:2.7.3'
 	implementation 'mysql:mysql-connector-java:8.0.28'
 	implementation group: 'io.springfox', name: 'springfox-boot-starter', version: '3.0.0'
 
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lotte/danuri/member/MemberApplication.java
+++ b/src/main/java/com/lotte/danuri/member/MemberApplication.java
@@ -2,9 +2,11 @@ package com.lotte.danuri.member;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableDiscoveryClient
 @EnableJpaAuditing
 public class MemberApplication {
 

--- a/src/main/java/com/lotte/danuri/member/cart/CartServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/cart/CartServiceImpl.java
@@ -29,7 +29,7 @@ public class CartServiceImpl implements CartService{
     @Override
     public List<CartRespDto> getProductsOfCart(CartReqDto dto) {
 
-        memberRepository.findById(dto.getMemberId()).orElseThrow(
+        memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS));
 
         return cartRepository.findByMemberId(dto.getMemberId()).orElseGet(ArrayList::new)
@@ -40,7 +40,7 @@ public class CartServiceImpl implements CartService{
 
     @Override
     public int register(CartInsertReqDto dto) {
-        Member member = memberRepository.findById(dto.getMemberId()).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
         cartRepository.save(dto.toEntity(member));

--- a/src/main/java/com/lotte/danuri/member/config/SwaggerConfiguration.java
+++ b/src/main/java/com/lotte/danuri/member/config/SwaggerConfiguration.java
@@ -1,11 +1,29 @@
 package com.lotte.danuri.member.config;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.actuate.endpoint.ExposableEndpoint;
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver;
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping;
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes;
+import org.springframework.boot.actuate.endpoint.web.ExposableWebEndpoint;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpointsSupplier;
+import org.springframework.boot.actuate.endpoint.web.servlet.WebMvcEndpointHandlerMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.util.StringUtils;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
@@ -29,4 +47,30 @@ public class SwaggerConfiguration {
             .version("1.0")
             .build();
     }
+
+    @Bean
+    public WebMvcEndpointHandlerMapping webEndpointServletHandlerMapping(
+        WebEndpointsSupplier webEndpointsSupplier, ServletEndpointsSupplier servletEndpointsSupplier,
+        ControllerEndpointsSupplier controllerEndpointsSupplier, EndpointMediaTypes endpointMediaTypes,
+        CorsEndpointProperties corsProperties, WebEndpointProperties webEndpointProperties, Environment environment) {
+
+        List<ExposableEndpoint<?>> allEndpoints = new ArrayList();
+        Collection<ExposableWebEndpoint> webEndpoints = webEndpointsSupplier.getEndpoints();
+        allEndpoints.addAll(webEndpoints);
+        allEndpoints.addAll(servletEndpointsSupplier.getEndpoints());
+        allEndpoints.addAll(controllerEndpointsSupplier.getEndpoints());
+        String basePath = webEndpointProperties.getBasePath();
+        EndpointMapping endpointMapping = new EndpointMapping(basePath);
+        boolean shouldRegisterLinksMapping = this.shouldRegisterLinksMapping(webEndpointProperties, environment, basePath);
+
+        return new WebMvcEndpointHandlerMapping(endpointMapping, webEndpoints, endpointMediaTypes, corsProperties.toCorsConfiguration()
+            , new EndpointLinksResolver(allEndpoints, basePath), shouldRegisterLinksMapping, null);
+    }
+
+    private boolean shouldRegisterLinksMapping(WebEndpointProperties webEndpointProperties,
+                                                Environment environment, String basePath) {
+        return webEndpointProperties.getDiscovery().isEnabled() &&
+            (StringUtils.hasText(basePath) || ManagementPortType.get(environment).equals(ManagementPortType.DIFFERENT));
+    }
+
 }

--- a/src/main/java/com/lotte/danuri/member/follow/FollowServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/follow/FollowServiceImpl.java
@@ -33,7 +33,7 @@ public class FollowServiceImpl implements FollowService {
     @Override
     public int register(FollowDto dto) {
 
-        Member member = memberRepository.findById(dto.getMemberId()).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 
@@ -53,7 +53,7 @@ public class FollowServiceImpl implements FollowService {
     @Override
     public List<StoreDto> getStoresByFollow(Long memberId) {
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findByIdAndFollow(memberId).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 
@@ -73,7 +73,7 @@ public class FollowServiceImpl implements FollowService {
     @Override
     public int delete(FollowDto dto) {
 
-        Member member = memberRepository.findById(dto.getMemberId()).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 

--- a/src/main/java/com/lotte/danuri/member/likes/LikesServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/likes/LikesServiceImpl.java
@@ -32,7 +32,7 @@ public class LikesServiceImpl implements LikesService{
 
     @Override
     public int register(LikesInsertReqDto dto) {
-        Member member = memberRepository.findById(dto.getMemberId()).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 

--- a/src/main/java/com/lotte/danuri/member/members/AdminServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/members/AdminServiceImpl.java
@@ -19,7 +19,7 @@ public class AdminServiceImpl implements AdminService{
     @Override
     public Long updateSellerAuth(SellerAuthReqDto dto) {
 
-        Member findMember = memberRepository.findById(dto.getMemberId()).orElseThrow(
+        Member findMember = memberRepository.findByIdAndDeletedDateIsNull(dto.getMemberId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
         findMember.updateStatus(dto.getStatus());

--- a/src/main/java/com/lotte/danuri/member/members/Member.java
+++ b/src/main/java/com/lotte/danuri/member/members/Member.java
@@ -6,24 +6,20 @@ import java.time.LocalDateTime;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
-import javax.persistence.EntityManager;
 import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.springframework.data.jpa.repository.Query;
 
 @Entity(name="member")
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class Member extends BaseEntity {
-
-    private Long authId;
 
     private String gender;
     private String phoneNumber;

--- a/src/main/java/com/lotte/danuri/member/members/MemberController.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberController.java
@@ -9,6 +9,7 @@ import com.lotte.danuri.member.likes.dto.LikesReqDto;
 import com.lotte.danuri.member.members.dto.MemberInfoReqDto;
 import com.lotte.danuri.member.members.dto.MemberReqDto;
 import com.lotte.danuri.member.members.dto.MembershipUpdateDto;
+import com.lotte.danuri.member.members.dto.SignUpDto;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -23,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
-@RequestMapping("/member")
+@RequestMapping("/")
 public class MemberController {
 
     private final MemberService memberService;
@@ -31,6 +32,12 @@ public class MemberController {
     private final CartService cartService;
     private final MyCouponService myCouponService;
     private final FollowService followService;
+
+    @PostMapping("/members")
+    @ApiOperation(value = "회원 정보 등록", notes = "회원 가입 후 정보 저장")
+    public ResponseEntity<?> save(@RequestBody SignUpDto dto) {
+        return new ResponseEntity<>(memberService.register(dto), HttpStatus.CREATED);
+    }
 
     @PatchMapping("/info")
     @ApiOperation(value = "회원 수정", notes = "회원의 개인정보 수정")
@@ -116,6 +123,4 @@ public class MemberController {
         return new ResponseEntity<>(rank, HttpStatus.OK);
 
     }
-
-
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberRepository.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberRepository.java
@@ -19,5 +19,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             + "AND m.deletedDate is null "
             + "AND f.deletedDate is null "
     )
-    Optional<Member> findById(Long memberId);
+    Optional<Member> findByIdAndFollow(Long memberId);
+
+    Optional<Member> findByIdAndDeletedDateIsNull(Long memberId);
 }

--- a/src/main/java/com/lotte/danuri/member/members/MemberService.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberService.java
@@ -3,10 +3,13 @@ package com.lotte.danuri.member.members;
 import com.lotte.danuri.member.members.dto.MemberInfoReqDto;
 import com.lotte.danuri.member.members.dto.MemberRespDto;
 import com.lotte.danuri.member.members.dto.SellerAuthReqDto;
+import com.lotte.danuri.member.members.dto.SignUpDto;
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberService {
+
+    Long register(SignUpDto dto);
 
     Long updateMemberInfo(MemberInfoReqDto dto);
 

--- a/src/main/java/com/lotte/danuri/member/members/MemberServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/members/MemberServiceImpl.java
@@ -1,17 +1,12 @@
 package com.lotte.danuri.member.members;
 
-import com.lotte.danuri.member.cart.CartRepository;
-import com.lotte.danuri.member.common.exception.codes.ErrorCode;
 import com.lotte.danuri.member.common.exception.codes.MemberErrorCode;
 import com.lotte.danuri.member.common.exception.exceptions.NoMemberException;
 import com.lotte.danuri.member.common.exception.exceptions.SellerStoreExistedException;
 import com.lotte.danuri.member.members.dto.MemberInfoReqDto;
 import com.lotte.danuri.member.members.dto.MemberRespDto;
-import com.lotte.danuri.member.members.dto.SellerAuthReqDto;
+import com.lotte.danuri.member.members.dto.SignUpDto;
 import com.lotte.danuri.member.store.StoreRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,9 +20,15 @@ public class MemberServiceImpl implements MemberService {
     private final StoreRepository storeRepository;
 
     @Override
+    public Long register(SignUpDto dto) {
+        Member member = memberRepository.save(dto.toEntity());
+        return member.getId();
+    }
+
+    @Override
     public Long updateMemberInfo(MemberInfoReqDto dto) {
 
-        Member findMember = memberRepository.findById(dto.getId()).orElseThrow(
+        Member findMember = memberRepository.findByIdAndDeletedDateIsNull(dto.getId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
         findMember.updateInfo(dto.getName(), dto.getAddress(), dto.getPhoneNumber());
@@ -38,7 +39,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MemberRespDto getMember(Long memberId) {
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 
@@ -55,7 +56,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public int delete(Long memberId) {
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 
@@ -72,7 +73,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public Long updateMemberShip(Long memberId, int rank) {
 
-        Member member = memberRepository.findById(memberId).orElseThrow(
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 

--- a/src/main/java/com/lotte/danuri/member/members/dto/SignUpDto.java
+++ b/src/main/java/com/lotte/danuri/member/members/dto/SignUpDto.java
@@ -1,0 +1,47 @@
+package com.lotte.danuri.member.members.dto;
+
+import com.lotte.danuri.member.members.Member;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SignUpDto {
+
+    @NotNull
+    @Size(min = 5, max = 12)
+    private String id;
+
+    @NotNull
+    @Size(min = 6, max = 20)
+    private String password;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String gender;
+
+    private int role;
+
+    @NotNull
+    private String phoneNumber;
+
+    @NotNull
+    private String address;
+
+    public Member toEntity() {
+        return Member.builder()
+            .address(address)
+            .gender(gender)
+            .name(name)
+            .phoneNumber(phoneNumber)
+            .role(role)
+            .build();
+    }
+
+}

--- a/src/main/java/com/lotte/danuri/member/store/StoreServiceImpl.java
+++ b/src/main/java/com/lotte/danuri/member/store/StoreServiceImpl.java
@@ -28,7 +28,7 @@ public class StoreServiceImpl implements StoreService {
         if(storeRepository.findByNameAndDeletedDateIsNull(dto.getName()).isPresent()) {
             throw new DuplicatedStoreNameException(StoreErrorCode.DUPLICATED_STORE_NAME.getMessage(), StoreErrorCode.DUPLICATED_STORE_NAME);
         }else {
-            Member findMember = memberRepository.findById(dto.getSellerId()).orElseThrow(
+            Member findMember = memberRepository.findByIdAndDeletedDateIsNull(dto.getSellerId()).orElseThrow(
                 () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
             );
 
@@ -54,7 +54,7 @@ public class StoreServiceImpl implements StoreService {
     @Override
     public int update(StoreDto dto) {
 
-        memberRepository.findById(dto.getSellerId()).orElseThrow(
+        memberRepository.findByIdAndDeletedDateIsNull(dto.getSellerId()).orElseThrow(
             () -> new NoMemberException(MemberErrorCode.NO_MEMBER_EXISTS.getMessage(), MemberErrorCode.NO_MEMBER_EXISTS)
         );
 
@@ -73,7 +73,7 @@ public class StoreServiceImpl implements StoreService {
     @Override
     public int updateImage(StoreDto dto) {
 
-        Member findMember = memberRepository.findById(dto.getSellerId()).orElseThrow();
+        Member findMember = memberRepository.findByIdAndDeletedDateIsNull(dto.getSellerId()).orElseThrow();
 
         if(storeRepository.findById(dto.getId()).isEmpty()) {
             throw new NoStoreException(StoreErrorCode.NO_STORE_EXISTS.getMessage(), StoreErrorCode.NO_STORE_EXISTS);

--- a/src/main/java/com/lotte/danuri/member/store/dto/StoreDto.java
+++ b/src/main/java/com/lotte/danuri/member/store/dto/StoreDto.java
@@ -26,13 +26,9 @@ public class StoreDto {
 
     private String address;
 
-    private String ownerName;
-
     private String ownerNumber;
 
     private String image;
-
-    private Double score;
 
     public Store toEntity(Member member) {
         return Store.builder()
@@ -40,8 +36,6 @@ public class StoreDto {
             .name(name)
             .description(description)
             .address(address)
-            .score(score)
-            .ownerName(ownerName)
             .ownerNumber(ownerNumber)
             .image(image)
             .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: member
+  main:
+    allow-bean-definition-overriding: true
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: refresh, health, beans, busrefresh

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -1,0 +1,5 @@
+spring:
+  cloud:
+    config:
+      uri: sbbro.xyz/config
+      name: member

--- a/src/test/java/com/lotte/danuri/member/store/StoreServiceTest.java
+++ b/src/test/java/com/lotte/danuri/member/store/StoreServiceTest.java
@@ -30,9 +30,7 @@ public class StoreServiceTest {
             .name("aaaaaaaaaaaaa")
             .address("서울특별시 중구")
             .description("aaaaaaaa")
-            .ownerName("aaa")
             .ownerNumber("010-1133-1133")
-            .score(0.0)
             .build();
 
         int result = storeService.register(dto);
@@ -48,9 +46,7 @@ public class StoreServiceTest {
             .name("adidas")
             .address("경기도 김포시")
             .description("아디다스 매장")
-            .ownerName("문인태")
             .ownerNumber("010-1122-1122")
-            .score(0.0)
             .build();
 
         assertThatThrownBy(() -> storeService.register(dto))
@@ -66,9 +62,7 @@ public class StoreServiceTest {
             .name("bbbb")
             .address("서울특별시 홍대")
             .description("bbbbbb")
-            .ownerName("bbb")
             .ownerNumber("010-9999-2222")
-            .score(0.0)
             .build();
 
         assertThatThrownBy(() -> storeService.register(dto))
@@ -97,7 +91,6 @@ public class StoreServiceTest {
             .name("hello nikes~!~!~!~~!!~!!")
             .address("서울특별시 강남구")
             .description("~~~!~!~!~!~!~!~!~!")
-            .ownerName("안채영")
             .ownerNumber("010-1111-1111")
             .build();
 
@@ -118,7 +111,6 @@ public class StoreServiceTest {
             .name("hello nikes!!!!")
             .address("서울특별시 강남구")
             .description("~~~!~!~!~!~!~!~!~!")
-            .ownerName("안채영")
             .ownerNumber("010-1111-1111")
             .build();
 


### PR DESCRIPTION
[작업 내용]
* 회원가입 시 apigateway -> auth에서 인증에 필요한 정보 예외 통과 후 회원 개인 정보는 Member에 저장
  * Auth에서 통신 요청할 API 구현
  * Service 및 Repository, DTO 추가 구현
    * 기존 findById 메소드가 follow와의 패치 조인된 쿼리로 되어있어 함수명 수정하여 적용
    * 필요한 findById 메소드는 findByIdAndDeletedDateIsNull 메소드로 구현하여 적용