### PR TITLE
[fix] OAuth 로그인 시 정보 제공 동의 안할 경우 로직 적용

### DIFF
--- a/src/main/java/com/lotte/danuri/member/members/dto/SignUpByOAuthDto.java
+++ b/src/main/java/com/lotte/danuri/member/members/dto/SignUpByOAuthDto.java
@@ -25,6 +25,11 @@ public class SignUpByOAuthDto {
     }
 
     public void update() {
+
+        if(birthday == null || gender == null) {
+            return;
+        }
+
         if(birthday.contains("-")) {
             birthday = birthday.replace("-", "");
         }


### PR DESCRIPTION
[작업 내용]
* OAuth 로그인 시 성별, 생년월일은 필수 동의 항목이 아니므로 null 값일 수 있기 때문에 로직 적용